### PR TITLE
do no set android:isGame="true" if it's already set

### DIFF
--- a/isgame.js
+++ b/isgame.js
@@ -16,9 +16,20 @@ module.exports = function(context) {
       if (err) {
         throw new Error('Unable to find AndroidManifest.xml: ' + err);
       }
-
-        var result = data.replace(/<application/g, '<application android:isGame="true"');
-
+        
+        var result;
+        
+        if (!(/<application[^>]*\bandroid:isGame="true"/).test(data)) {
+            
+            result = data.replace(/<application/g, '<application android:isGame="true"');
+            
+        }
+        else {
+            
+            result = data;
+            
+        }
+        
         fs.writeFile(manifestFile, result, 'utf8', function (err) {
           if (err) throw new Error('Unable to write into AndroidManifest.xml: ' + err);
         })


### PR DESCRIPTION
Cordova crashes when one runs an app multiple time with this plugin installed because the AndroidManifest.xml's "application" element ends up looking like:

`<application android:isGame="true" ...  android:isGame="true" ...`

This change simply verifies whether android:isGame="true" is not present on the tag before adding. It uses the following regexp for the check:

`/<application[^>]*\bandroid:isGame="true"/`

The regexp could probably be changed to also handle "false" cases like so:

`/<application[^>]*\bandroid:isGame="(?:true|false)"/`

but arguably, a regexp is not the right tool for the job at all anyways, so this is only a _simple_ fix, to a _simple_ problem that was dealt with with _simplicity_.
